### PR TITLE
https://github.com/larsimmisch/homebrew-avr is depricated and replace…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Once you're ready, here are the commands to install the needed tools:
 
 ```bash
 $ brew install avrdude
-$ brew tap larsimmisch/avr
+$ brew tap osx-cross/avr
 $ brew install avr-binutils
 $ brew install avr-gcc
 $ brew install avr-libc


### PR DESCRIPTION
…d with https://github.com/osx-cross/homebrew-avr/
I just ran across this wrinkle when setting up a new machine